### PR TITLE
ansible: Support do_as in bionic

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -965,17 +965,19 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         """
         Perform a command as the requested user. Behaves like subp()
 
-        Is there a more platform-independant way? sudo -D failed for me
+        Note: We pass `PATH` to the user env by using `env`. This could be
+        probably simplified after bionic EOL by using
+        `su --whitelist-environment=PATH ...`, more info on:
+        https://lore.kernel.org/all/20180815110445.4qefy5zx5gfgbqly@ws.net.home/T/
         """
         directory = f"cd {cwd} && " if cwd else ""
         return subp.subp(
             [
                 "su",
-                "--whitelist-environment=PATH",
                 "-",
                 user,
                 "-c",
-                directory + " ".join(command),
+                directory + "env PATH=$PATH " + " ".join(command),
             ],
             **kwargs,
         )


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
ansible: Support do_as in bionic
```

## Additional Context
<!-- If relevant -->
https://github.com/canonical/cloud-init/pull/1778#pullrequestreview-1150213682
https://lore.kernel.org/all/20180815110445.4qefy5zx5gfgbqly@ws.net.home/T/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```sh
CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_OS_IMAGE=bionic tox -e integration-tests -- -vv tests/integration_tests/modules/test_ansible.py::TestAnsibleController
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
